### PR TITLE
Configure S3 Backend and test vpc creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ server-key.pem
 
 # Ignore backend hcl file
 backend.hcl
+
+# Ignore key-pair
+*.pem
+*.pub
+tf-key-pair

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ terraform.rc
 server-key.pem
 
 # Ignore backend hcl file
-backend.hcl
+*.hcl
 
 # Ignore key-pair
 *.pem

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Seat-Catcher AWS Infrastructure management repository
 - Replace `{env}` with the appropriate environment (e.g., `dev`, `prod`, `global`).
 - Always review the `PLAN` logs carefully before applying changes.
 - Ensure your AWS credentials are securely managed in your console (e.g., using environment variables or AWS CLI profiles).
-    - If AWS credentials are not configured properly, 
+    - If AWS credentials are not configured properly, s3 related error occurs.
 
 ### S3 Backend Configuration
 - Terraform state is stored in an S3 bucket. Ensure the bucket is properly configured with the correct permissions.

--- a/README.md
+++ b/README.md
@@ -2,29 +2,56 @@
 Seat-Catcher AWS Infrastructure management repository
 
 ## Considerations
-- We have to reduce cost as many as possible -> Minimum cost but easy to use in development
-- We don't consider about high availability and failover in dev enviroment
+- We have to reduce cost as much as possible -> Minimum cost but easy to use in development
+- We don't consider high availability and failover in the dev environment
 
 ## Architecture Diagram
 - Updating...
 
 ## HOW TO RUN
 
-- See carefully "PLAN" logs when you modify cloud architecture
+### Typical Terraform Workflow
+1. **Initialize the backend**:
+   ```bash
+   terraform init -backend-config={env}_backend.hcl
+   ```
 
-```terraform
-# terraform reconfigure
-terraform init -reconfigure -backend-config=backend.hcl
+2. **Check the execution plan**:
+   ```bash
+   terraform plan -var-file={env}.tfvars
+   ```
 
-# if any changes in modules,
-terraform init -backend-config=backend.hcl
-```
-## How can i create Public key for SSH connection?
-```bash
-# -t: Type of encrypt
-# -b: # of bits
-# -C: comment
-# -f: save path
-# -N: encrypt option
-ssh-keygen -t rsa -b 4096 -C "" -f "{path-to-save-key}/{any-name}" -N ""
-```
+3. **Apply the changes**:
+   ```bash
+   terraform apply -var-file={env}.tfvars
+   ```
+
+4. **Destroy resources (if needed)**:
+   ```bash
+   terraform destroy -var-file={env}.tfvars
+   ```
+
+### Notes
+- Replace `{env}` with the appropriate environment (e.g., `dev`, `prod`, `global`).
+- Always review the `PLAN` logs carefully before applying changes.
+- Ensure your AWS credentials are securely managed in your console (e.g., using environment variables or AWS CLI profiles).
+    - If AWS credentials are not configured properly, 
+
+### S3 Backend Configuration
+- Terraform state is stored in an S3 bucket. Ensure the bucket is properly configured with the correct permissions.
+- Example `backend.hcl`:
+  ```hcl
+  bucket = "bucket_name"
+  key    = "state_file_key_name"
+  region = "ap-northeast-2"
+  ```
+
+- To reconfigure the backend:
+  ```bash
+  terraform init -reconfigure -backend-config={env}_backend.hcl
+  ```
+
+### Security Best Practices
+- Do not hardcode sensitive information (e.g., AWS access keys) in `.tfvars` or code files.
+- Use environment variables or AWS CLI profiles to manage credentials securely.
+- But we used tfvars files in managing sensitive information. Be aware of it!!

--- a/README.md
+++ b/README.md
@@ -13,5 +13,18 @@ Seat-Catcher AWS Infrastructure management repository
 - See carefully "PLAN" logs when you modify cloud architecture
 
 ```terraform
-updating...
+# terraform reconfigure
+terraform init -reconfigure -backend-config=backend.hcl
+
+# if any changes in modules,
+terraform init -backend-config=backend.hcl
+```
+## How can i create Public key for SSH connection?
+```bash
+# -t: Type of encrypt
+# -b: # of bits
+# -C: comment
+# -f: save path
+# -N: encrypt option
+ssh-keygen -t rsa -b 4096 -C "" -f "{path-to-save-key}/{any-name}" -N ""
 ```

--- a/enviroments/dev/.terraform.lock.hcl
+++ b/enviroments/dev/.terraform.lock.hcl
@@ -23,3 +23,41 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f68562e073722c378d2f3529eb80ad463f12c44aa5523d558ae3b69f4de5ca1f",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.2"
+  hashes = [
+    "h1:JlMZD6nYqJ8sSrFfEAH0Vk/SL8WLZRmFaMUF9PJK5wM=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.6"
+  hashes = [
+    "h1:dYSb3V94K5dDMtrBRLPzBpkMTPn+3cXZ/kIJdtFL+2M=",
+    "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
+    "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",
+    "zh:4578ca03d1dd0b7f572d96bd03f744be24c726bfd282173d54b100fd221608bb",
+    "zh:6c475491d1250050765a91a493ef330adc24689e8837a0f07da5a0e1269e11c1",
+    "zh:81bde94d53cdababa5b376bbc6947668be4c45ab655de7aa2e8e4736dfd52509",
+    "zh:abdce260840b7b050c4e401d4f75c7a199fafe58a8b213947a258f75ac18b3e8",
+    "zh:b754cebfc5184873840f16a642a7c9ef78c34dc246a8ae29e056c79939963c7a",
+    "zh:c928b66086078f9917aef0eec15982f2e337914c5c4dbc31dd4741403db7eb18",
+    "zh:cded27bee5f24de6f2ee0cfd1df46a7f88e84aaffc2ecbf3ff7094160f193d50",
+    "zh:d65eb3867e8f69aaf1b8bb53bd637c99c6b649ba3db16ded50fa9a01076d1a27",
+    "zh:ecb0c8b528c7a619fa71852bb3fb5c151d47576c5aab2bf3af4db52588722eeb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/enviroments/dev/ec2.tf
+++ b/enviroments/dev/ec2.tf
@@ -1,0 +1,7 @@
+module "dev-instance" {
+  source        = "../../modules/ec2"
+  public_subnet = module.dev_vpc.public_subnet_id
+  # use default instance type (t2.micro)
+  instance_key_name  = var.dev_instance_key_name
+  key_pair_save_path = var.dev_key_pair_save_path
+}

--- a/enviroments/dev/main.tf
+++ b/enviroments/dev/main.tf
@@ -5,11 +5,14 @@ terraform {
       version = "~> 5.0"
     }
   }
+
+  backend "s3" {
+  }
 }
 
 # Configure the AWS Provider
 provider "aws" {
-  region = var.region
+  region     = var.region
   access_key = var.access_key
   secret_key = var.secret_key
 }

--- a/enviroments/dev/outputs.tf
+++ b/enviroments/dev/outputs.tf
@@ -1,0 +1,3 @@
+output "dev_instance_public_ip" {
+  value = module.dev-instance.dev_instance_public_ip
+}

--- a/enviroments/dev/s3.tf
+++ b/enviroments/dev/s3.tf
@@ -1,4 +1,6 @@
-module "s3" {
+# Bucket for terraform state is managed by administrator, not terraform!!!
+
+module "seatcatcher_images" {
   source      = "../../modules/s3"
-  bucket_name = var.terraform_state_bucket
+  bucket_name = var.seatcatcher_images_bucket
 }

--- a/enviroments/dev/s3.tf
+++ b/enviroments/dev/s3.tf
@@ -1,0 +1,4 @@
+module "s3" {
+  source      = "../../modules/s3"
+  bucket_name = var.terraform_state_bucket
+}

--- a/enviroments/dev/variables.tf
+++ b/enviroments/dev/variables.tf
@@ -44,3 +44,48 @@ variable "backend_team" {
   type        = list(string)
   sensitive   = true
 }
+
+variable "dev_vpc_cidr_block" {
+  description = "VPC CIDR block"
+  type        = string
+}
+
+variable "dev_public_subnet_cidr" {
+  description = "Public subnet CIDR block"
+  type        = string
+}
+
+variable "dev_private_subnet_cidr" {
+  description = "Private subnet CIDR block"
+  type        = string
+}
+
+variable "dev_vpc_tag_name" {
+  description = "Development VPC tag name"
+  type        = string
+}
+
+variable "prod_vpc_cidr_block" {
+  description = "VPC CIDR block"
+  type        = string
+}
+
+variable "prod_public_subnet_cidr" {
+  description = "Public subnet CIDR block"
+  type        = string
+}
+
+variable "prod_private_subnet_cidr" {
+  description = "Private subnet CIDR block"
+  type        = string
+}
+
+variable "prod_vpc_tag_name" {
+  description = "Production VPC tag name"
+  type        = string
+}
+
+variable "terraform_state_bucket" {
+  description = "Terraform state bucket name"
+  type        = string
+}

--- a/enviroments/dev/variables.tf
+++ b/enviroments/dev/variables.tf
@@ -65,6 +65,21 @@ variable "dev_vpc_tag_name" {
   type        = string
 }
 
+variable "dev_igw_name" {
+  description = "Internet gateway name"
+  type        = string
+}
+
+variable "dev_private_subnet_tag_name" {
+  description = "Private subnet tag name"
+  type        = string
+}
+
+variable "dev_public_subnet_tag_name" {
+  description = "Public subnet tag name"
+  type        = string
+}
+
 variable "prod_vpc_cidr_block" {
   description = "VPC CIDR block"
   type        = string
@@ -88,4 +103,23 @@ variable "prod_vpc_tag_name" {
 variable "terraform_state_bucket" {
   description = "Terraform state bucket name"
   type        = string
+  sensitive   = true
+}
+
+variable "seatcatcher_images_bucket" {
+  description = "Seatcatcher images bucket name"
+  type        = string
+  sensitive   = true
+}
+
+variable "dev_instance_key_name" {
+  description = "Key name for the dev environment instances"
+  type        = string
+  sensitive   = true
+}
+
+variable "dev_key_pair_save_path" {
+  description = "Path to save the key pair for the dev environment instances"
+  type        = string
+  sensitive   = true
 }

--- a/enviroments/dev/vpc.tf
+++ b/enviroments/dev/vpc.tf
@@ -1,17 +1,20 @@
 module "dev_vpc" {
-  source              = "../../modules/vpc"
-  vpc_cidr_block      = var.dev_vpc_cidr_block
-  public_subnet_cidr  = var.dev_public_subnet_cidr
-  private_subnet_cidr = var.dev_private_subnet_cidr
-  vpc_tag_name        = var.dev_vpc_tag_name
-  availability_zone   = element(data.aws_availability_zones.available.names, 0)
+  source                  = "../../modules/vpc"
+  vpc_cidr_block          = var.dev_vpc_cidr_block
+  public_subnet_cidr      = var.dev_public_subnet_cidr
+  private_subnet_cidr     = var.dev_private_subnet_cidr
+  vpc_tag_name            = var.dev_vpc_tag_name
+  availability_zone       = element(data.aws_availability_zones.available.names, 0)
+  igw_name                = var.dev_igw_name
+  public_subnet_tag_name  = var.dev_public_subnet_tag_name
+  private_subnet_tag_name = var.dev_private_subnet_tag_name
 }
 
-module "prod_vpc" {
-  source              = "../../modules/vpc"
-  vpc_cidr_block      = var.prod_vpc_cidr_block
-  public_subnet_cidr  = var.prod_public_subnet_cidr
-  private_subnet_cidr = var.prod_private_subnet_cidr
-  vpc_tag_name        = var.prod_vpc_tag_name
-  availability_zone   = element(data.aws_availability_zones.available.names, 0)
-}
+# module "prod_vpc" {
+#   source              = "../../modules/vpc"
+#   vpc_cidr_block      = var.prod_vpc_cidr_block
+#   public_subnet_cidr  = var.prod_public_subnet_cidr
+#   private_subnet_cidr = var.prod_private_subnet_cidr
+#   vpc_tag_name        = var.prod_vpc_tag_name
+#   availability_zone   = element(data.aws_availability_zones.available.names, 0)
+# }

--- a/enviroments/dev/vpc.tf
+++ b/enviroments/dev/vpc.tf
@@ -1,0 +1,17 @@
+module "dev_vpc" {
+  source              = "../../modules/vpc"
+  vpc_cidr_block      = var.dev_vpc_cidr_block
+  public_subnet_cidr  = var.dev_public_subnet_cidr
+  private_subnet_cidr = var.dev_private_subnet_cidr
+  vpc_tag_name        = var.dev_vpc_tag_name
+  availability_zone   = element(data.aws_availability_zones.available.names, 0)
+}
+
+module "prod_vpc" {
+  source              = "../../modules/vpc"
+  vpc_cidr_block      = var.prod_vpc_cidr_block
+  public_subnet_cidr  = var.prod_public_subnet_cidr
+  private_subnet_cidr = var.prod_private_subnet_cidr
+  vpc_tag_name        = var.prod_vpc_tag_name
+  availability_zone   = element(data.aws_availability_zones.available.names, 0)
+}

--- a/enviroments/global/.terraform.lock.hcl
+++ b/enviroments/global/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.92.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:ZnpTxMfg5PThZc5WZCsZELinsR0gPhdTpNmXjVcf7aE=",
+    "zh:1d3a0b40831360e8e988aee74a9ff3d69d95cb541c2eae5cb843c64303a091ba",
+    "zh:3d29cbced6c708be2041a708d25c7c0fc22d09e4d0b174360ed113bfae786137",
+    "zh:4341a203cf5820a0ca18bb514ae10a6c113bc6a728fb432acbf817d232e8eff4",
+    "zh:4a49e2d91e4d92b6b93ccbcbdcfa2d67935ce62e33b939656766bb81b3fd9a2c",
+    "zh:54c7189358b37fd895dedbabf84e509c1980a8c404a1ee5b29b06e40497b8655",
+    "zh:5d8bb1ff089c37cb65c83b4647f1981fded993e87d8132915d92d79f29e2fcd8",
+    "zh:618f2eb87cd65b245aefba03991ad714a51ff3b841016ef68e2da2b85d0b2325",
+    "zh:7bce07bc542d0588ca42bac5098dd4f8af715417cd30166b4fb97cedd44ab109",
+    "zh:81419eab2d8810beb114b1ff5cbb592d21edc21b809dc12bb066e4b88fdd184a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9dea39d4748eeeebe2e76ca59bca4ccd161c2687050878c47289a98407a23372",
+    "zh:d692fc33b67ac89e916c8f9233d39eacab8c438fe10172990ee9d94fba5ca372",
+    "zh:d9075c7da48947c029ba47d5985e1e8e3bf92367bfee8ca1ff0e747765e779a1",
+    "zh:e81c62db317f3b640b2e04eba0ada8aa606bcbae0152c09f6242e86b86ef5889",
+    "zh:f68562e073722c378d2f3529eb80ad463f12c44aa5523d558ae3b69f4de5ca1f",
+  ]
+}

--- a/enviroments/global/main.tf
+++ b/enviroments/global/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region     = var.region
+  access_key = var.access_key
+  secret_key = var.secret_key
+}
+
+data "aws_availability_zones" "available" {}

--- a/enviroments/global/route53.tf
+++ b/enviroments/global/route53.tf
@@ -1,0 +1,18 @@
+data "terraform_remote_state" "dev" {
+  backend = "s3"
+  config = {
+    bucket = var.terraform_state_bucket
+    key    = var.dev_key
+    region = var.region
+  }
+}
+
+module "dns" {
+  source               = "../../modules/route53"
+  domain_name          = var.domain_name
+  api_instance_ip      = data.terraform_remote_state.dev.outputs.dev_instance_public_ip
+  docs_instance_ip     = data.terraform_remote_state.dev.outputs.dev_instance_public_ip
+  dev_sub_domain_name  = var.dev_sub_domain_name
+  dev_api_domain_name  = var.dev_api_domain_name
+  dev_docs_domain_name = var.dev_docs_domain_name
+}

--- a/enviroments/global/variables.tf
+++ b/enviroments/global/variables.tf
@@ -19,11 +19,13 @@ variable "secret_key" {
 variable "terraform_state_bucket" {
   description = "Name of the S3 bucket to store Terraform state"
   type        = string
+  sensitive = true
 }
 
 variable "dev_key" {
   description = "Name of state dev_key"
   type        = string
+  sensitive = true
 }
 
 variable "domain_name" {
@@ -34,14 +36,17 @@ variable "domain_name" {
 variable "dev_sub_domain_name" {
   description = "Development sub domain name"
   type        = string
+  sensitive = true
 }
 
 variable "dev_api_domain_name" {
   description = "Development API domain name"
   type        = string
+  sensitive = true
 }
 
 variable "dev_docs_domain_name" {
   description = "Development docs domain name"
   type        = string
+  sensitive = true
 }

--- a/enviroments/global/variables.tf
+++ b/enviroments/global/variables.tf
@@ -1,0 +1,47 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "access_key" {
+  description = "AWS access key"
+  type        = string
+  sensitive   = true
+}
+
+variable "secret_key" {
+  description = "AWS secret key"
+  type        = string
+  sensitive   = true
+}
+
+variable "terraform_state_bucket" {
+  description = "Name of the S3 bucket to store Terraform state"
+  type        = string
+}
+
+variable "dev_key" {
+  description = "Name of state dev_key"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Domain name"
+  type        = string
+}
+
+variable "dev_sub_domain_name" {
+  description = "Development sub domain name"
+  type        = string
+}
+
+variable "dev_api_domain_name" {
+  description = "Development API domain name"
+  type        = string
+}
+
+variable "dev_docs_domain_name" {
+  description = "Development docs domain name"
+  type        = string
+}

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -9,11 +9,10 @@ data "aws_ami" "amzn-linux-2023-ami" {
 }
 
 resource "aws_instance" "dev_api_instance" {
-  count         = var.instance_count
-  ami           = data.aws_ami.amzn-linux-2023-ami.id
-  instance_type = var.instance_type
-  subnet_id     = element(var.subnets, 0)
-  user_data     = file("../scripts/cloud_init.sh")
+  ami                         = data.aws_ami.amzn-linux-2023-ami.id
+  instance_type               = var.instance_type
+  subnet_id                   = element(var.subnets, 0)
+  user_data                   = file("../scripts/cloud_init.sh")
   associate_public_ip_address = true
 
   tags = {
@@ -22,7 +21,6 @@ resource "aws_instance" "dev_api_instance" {
 }
 
 resource "aws_instance" "dev_docs_instance" {
-  count                       = var.instance_count
   ami                         = data.aws_ami.amzn-linux-2023-ami.id
   instance_type               = var.instance_type
   subnet_id                   = element(var.subnets, 0)

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -1,3 +1,11 @@
 output "instance_ids" {
   value = [for ec2 in aws_instance.this : ec2.id]
 }
+
+output "api_instance_public_ip" {
+  value = aws_instance.dev_api_instance.public_ip
+}
+
+output "docs_instance_public_ip" {
+  value = aws_instance.dev_docs_instance.public_ip
+}

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -1,11 +1,3 @@
-output "instance_ids" {
-  value = [for ec2 in aws_instance.this : ec2.id]
-}
-
-output "api_instance_public_ip" {
-  value = aws_instance.dev_api_instance.public_ip
-}
-
-output "docs_instance_public_ip" {
-  value = aws_instance.dev_docs_instance.public_ip
+output "dev_instance_public_ip" {
+  value = aws_instance.instance.public_ip
 }

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -8,9 +8,3 @@ variable "instance_type" {
   type        = string
   default     = "t2.micro"
 }
-
-variable "instance_count" {
-  description = "Number of instances"
-  type        = number
-  default     = 1
-}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,10 +1,21 @@
-variable "subnets" {
-  description = "Subnets"
-  type        = list(string)
+variable "public_subnet" {
+  description = "public subnet for the instance"
+  type        = string
 }
 
 variable "instance_type" {
   description = "Instance type"
   type        = string
   default     = "t2.micro"
+}
+
+variable "instance_key_name" {
+  description = "Key name"
+  type        = string
+  sensitive = true
+}
+
+variable "key_pair_save_path" {
+  description = "Path to save the key pair"
+  type        = string
 }

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -2,33 +2,25 @@ resource "aws_route53_zone" "main" {
   name = var.domain_name
 }
 
-resource "aws_route53_zone" "dev" {
-  name = "dev.${var.domain_name}"
-
-  tags = {
-    Environment = "dev"
-  }
-}
-
-resource "aws_route53_record" "dev-ns" {
+resource "aws_route53_record" "dev-subdomain-ns" {
   zone_id = aws_route53_zone.main.zone_id
-  name    = "dev.${var.domain_name}"
+  name    = "dev"
   type    = "NS"
   ttl     = "30"
-  records = aws_route53_zone.dev.name_servers
+  records = aws_route53_zone.main.name_servers
 }
 
 resource "aws_route53_record" "dev-api" {
-  zone_id = aws_route53_zone.dev.zone_id
-  name    = "api.dev.${var.domain_name}"
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "${var.dev_api_domain_name}"
   type    = "A"
   ttl     = "30"
   records = [var.api_instance_ip]
 }
 
 resource "aws_route53_record" "dev-docs" {
-  zone_id = aws_route53_zone.dev.zone_id
-  name    = "docs.dev.${var.domain_name}"
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "${var.dev_docs_domain_name}"
   type    = "A"
   ttl     = "30"
   records = [var.docs_instance_ip]

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -12,3 +12,18 @@ variable "docs_instance_ip" {
   description = "Public IP of Docs instance"
   type        = string
 }
+
+variable "dev_sub_domain_name" {
+  description = "Sub domain name"
+  type        = string
+}
+
+variable "dev_api_domain_name" {
+  description = "API domain name"
+  type        = string
+}
+
+variable "dev_docs_domain_name" {
+  description = "Docs domain name"
+  type        = string
+}

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,0 +1,17 @@
+resource "aws_s3_bucket" "s3" {
+  bucket        = var.bucket_name
+  force_destroy = true
+
+  tags = {
+    Name        = "Terraform state storage"
+    Environment = "Dev"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "bucket_versioning" {
+  bucket = aws_s3_bucket.s3.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  description = "Terraform state bucket"
+  type        = string
+}

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -1,4 +1,5 @@
 variable "bucket_name" {
   description = "Terraform state bucket"
   type        = string
+  sensitive = true
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -13,7 +13,7 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "public-subnet"
+    Name = var.public_subnet_tag_name
   }
 }
 
@@ -23,7 +23,28 @@ resource "aws_subnet" "private" {
   availability_zone = element(data.aws_availability_zones.available.names, 0)
 
   tags = {
-    Name = "private-subnet"
+    Name = var.private_subnet_tag_name
+  }
+}
+
+resource "aws_internet_gateway" "internet_gateway" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = var.igw_name
+  }
+}
+
+resource "aws_route_table" "internet_gateway_route_table" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.internet_gateway.id
+  }
+
+  tags = {
+    Name = "internet-gateway-route-table"
   }
 }
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,13 +1,13 @@
-resource "aws_vpc" "dev" {
+resource "aws_vpc" "vpc" {
   cidr_block = var.vpc_cidr_block
 
   tags = {
-    Name = "dev-vpc"
+    Name = var.vpc_tag_name
   }
 }
 
 resource "aws_subnet" "public" {
-  vpc_id                  = aws_vpc.dev.id
+  vpc_id                  = aws_vpc.vpc.id
   cidr_block              = var.public_subnet_cidr
   availability_zone       = element(data.aws_availability_zones.available.names, 0)
   map_public_ip_on_launch = true
@@ -18,7 +18,7 @@ resource "aws_subnet" "public" {
 }
 
 resource "aws_subnet" "private" {
-  vpc_id            = aws_vpc.dev.id
+  vpc_id            = aws_vpc.vpc.id
   cidr_block        = var.private_subnet_cidr
   availability_zone = element(data.aws_availability_zones.available.names, 0)
 

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,5 +1,5 @@
 output "vpc_id" {
-  value = aws_vpc.dev.id
+  value = aws_vpc.vpc.id
 }
 
 output "public_subnet_id" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -22,3 +22,18 @@ variable "vpc_tag_name" {
   description = "value of the Name tag for the VPC"
   type        = string
 }
+
+variable "public_subnet_tag_name" {
+  description = "value of the Name tag for the public subnet"
+  type        = string
+}
+
+variable "private_subnet_tag_name" {
+  description = "value of the Name tag for the private subnet"
+  type        = string
+}
+
+variable "igw_name" {
+  description = "value of the Name tag for the internet gateway"
+  type        = string
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -17,3 +17,8 @@ variable "availability_zone" {
   description = "Availability zone"
   type        = string
 }
+
+variable "vpc_tag_name" {
+  description = "value of the Name tag for the VPC"
+  type        = string
+}

--- a/scripts/cloud_init.sh
+++ b/scripts/cloud_init.sh
@@ -25,3 +25,11 @@ fi
 
 sudo service docker start
 sudo systemctl enable docker
+
+# Install Docker Compose
+sudo apt-get install docker-compose-plugin -y
+
+if [ -z "$(docker-compose --version)" ]; then
+  echo "Docker Compose is not installed"
+  exit 1
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - Terraform 상태 저장을 위해 S3 백엔드와 S3 버킷 모듈이 추가되었습니다.
  - 개발 및 생산 환경에 맞춘 VPC와 서브넷 구성 옵션이 도입되었습니다.
  - EC2 인스턴스의 공인 IP 정보가 출력되어 인스턴스 접근성이 향상되었습니다.
  - 초기화 스크립트에 Docker Compose 플러그인 설치 및 검증 기능이 추가되었습니다.
  - Route 53 구성에서 단일 존을 사용하도록 통합되고, 레코드 명명 규칙이 수정되었습니다.
  - 새로운 Terraform 변수가 추가되어 AWS 구성 및 도메인 관리를 향상시켰습니다.
  - Terraform 공급자 및 원격 상태 데이터 소스가 추가되었습니다.
  - 새로운 EC2 인스턴스 모듈 구성이 추가되었습니다.

- **리팩토링**
  - EC2 인스턴스의 동적 스케일링 기능이 제거되고, VPC 식별 및 태깅 방식이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->